### PR TITLE
Add option for keyphrase output/length limits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "keyphrases"
-version = "0.1.6"
+version = "0.3.0"
 dependencies = [
  "regex",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "WTFPL"
 name = "keyphrases"
 readme = "README.md"
 repository = "https://github.com/jjoeldaniel/keyphrases.rs"
-version = "0.2.0"
+version = "0.3.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ To use keyphrases.rs in your Rust project, add the following line to your Cargo.
 
 ```toml
 [dependencies]
-keyphrases = "0.2.0"
+keyphrases = "0.3.0"
 ```
 
 ## Usage

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,8 +63,8 @@ impl KeyPhraseExtractor {
     /// Returns:
     ///
     /// A KeyPhraseExtractor struct
-    pub fn new(str: &str, top_n: usize) -> KeyPhraseExtractor {
-        let content_phrases: Vec<Vec<String>> = extract_content_phrases(&String::from(str));
+    pub fn new(str: &str, top_n: usize, max_length: usize) -> KeyPhraseExtractor {
+        let content_phrases: Vec<Vec<String>> = extract_content_phrases(&String::from(str), max_length);
 
         // maps
         let mut word_freq: HashMap<String, usize> = HashMap::new();
@@ -235,7 +235,7 @@ fn extract_content_words(words: &Vec<String>) -> Vec<String> {
 /// Returns:
 ///
 /// A vector of vectors of strings.
-fn extract_content_phrases(input: &str) -> Vec<Vec<String>> {
+fn extract_content_phrases(input: &str, max_length: usize) -> Vec<Vec<String>> {
     // stopwords
     let stopwords: HashSet<String> = load_stopwords();
 
@@ -252,10 +252,24 @@ fn extract_content_phrases(input: &str) -> Vec<Vec<String>> {
                 // If word is a stopword, push the phrase, clear, and
                 // move to the next split
                 if stopwords.contains(&word.to_ascii_lowercase()) {
+
+                    // if phrase is about to be over max length
+                    if content_phrase.len() == max_length {
+                        content_phrase.clear();
+                        continue;
+                    } 
+
                     content_phrases.push(content_phrase.clone());
                     content_phrase.clear();
                     continue;
                 } else {
+
+                    // if phrase is about to be over max length
+                    if content_phrase.len() == max_length {
+                        content_phrase.clear();
+                        continue;
+                    } 
+
                     // Append the current word to the phrase
                     content_phrase.push(String::from(word.to_owned()).to_ascii_lowercase());
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ use std::collections::HashSet;
 /// * `word_deg`: A HashMap that maps each word to its degree. The degree of a word is the number of
 /// words that are one edit distance away from it.
 pub struct KeyPhraseExtractor {
+    top_n: usize,
     message: String,
     content_phrases: Vec<Vec<String>>,
     word_freq: HashMap<String, usize>,
@@ -62,7 +63,7 @@ impl KeyPhraseExtractor {
     /// Returns:
     ///
     /// A KeyPhraseExtractor struct
-    pub fn new(str: &str) -> KeyPhraseExtractor {
+    pub fn new(str: &str, top_n: usize) -> KeyPhraseExtractor {
         let content_phrases: Vec<Vec<String>> = extract_content_phrases(&String::from(str));
 
         // maps
@@ -73,6 +74,7 @@ impl KeyPhraseExtractor {
         let message = String::from(str);
 
         return KeyPhraseExtractor {
+            top_n,
             message,
             content_phrases,
             word_freq,
@@ -101,6 +103,11 @@ impl KeyPhraseExtractor {
 
         phrase_degree_score.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap());
         phrase_degree_score.dedup();
+
+        let fill: (f32, String) = (0.0, String::from(""));
+        phrase_degree_score.resize(self.top_n, fill);
+        phrase_degree_score.dedup();
+
         return phrase_degree_score;
     }
 

--- a/tests/lib_tests.rs
+++ b/tests/lib_tests.rs
@@ -4,7 +4,7 @@ mod tests {
     #[test]
     fn test_extract() {
         let test_string: &str = "Feature extraction is not that complex. There are many algorithms available that can help you with feature extraction. Rapid Automatic Keyword Extraction is one of those.";
-        let kp = KeyPhraseExtractor::new(test_string, 3);
+        let kp = KeyPhraseExtractor::new(test_string, 3, 2);
 
         for phrase in kp.get_keywords() {
             println!("{:?}", phrase);

--- a/tests/lib_tests.rs
+++ b/tests/lib_tests.rs
@@ -4,7 +4,12 @@ mod tests {
     #[test]
     fn test_extract() {
         let test_string: &str = "Feature extraction is not that complex. There are many algorithms available that can help you with feature extraction. Rapid Automatic Keyword Extraction is one of those.";
-        let kp = KeyPhraseExtractor::new(test_string);
+        let kp = KeyPhraseExtractor::new(test_string, 3);
+
+        for phrase in kp.get_keywords() {
+            println!("{:?}", phrase);
+        }
+        // assert!(false);
 
         assert!(!kp.get_keywords().is_empty());
         assert!(!kp.get_content_phrases().is_empty());


### PR DESCRIPTION
## Whats Changed

* Added `top_n`, an option in `new()` that allows for limits to a top `n` number of keyphrases in `get_keywords()`
* Resolves #3 
* Resolves #7 