### PR TITLE
- improve: removed unnecessary hashmap copy

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,8 +93,8 @@ impl KeyPhraseExtractor {
 
             // Get cumulative score
             for word in &phrase {
-                cum_score += *self.get_word_deg().get(word).unwrap() as f32
-                    / *self.get_word_freq().get(word).unwrap() as f32;
+                cum_score += *self.word_deg.get(word).unwrap() as f32
+                    / *self.word_freq.get(word).unwrap() as f32;
             }
 
             // Insert cumulative score and phrase into list


### PR DESCRIPTION
Hi, first of all thanks for your library, it's really cool. I was using it in a project and I found a very useful improvement we can implement. I wrote this explanation and I hope it could make sense to you so we can merge it and release a new version 🙌🏼.

For any text we generate:

- P: Phrases
- W: Words
- W': Unique words
- Hashmap of size W'

Then to get keywords (in general terms) we create C copies of that Hashmap (call the word_freq and word_def getters), where C is:

C = P * W * 2

What happens when we have a long and pooly connected text? In a simple example having:
~300.000 words
~100.000 unique words

We could be creating 60.000.000.000 copies of a Hashap of size 100K which is really slow and underperformant :(

Testing on macOS M1 Max, we can see a performance improve of 14666x (in debug mode) just using the internal Hashmaps in place of call the getter that creates a copy.

Thanks!